### PR TITLE
fix the OreSpawn integration and stop EMe from acting like it's NMe

### DIFF
--- a/src/main/java/com/mcmoddev/orespawn/EndMetalsOreSpawn.java
+++ b/src/main/java/com/mcmoddev/orespawn/EndMetalsOreSpawn.java
@@ -15,49 +15,115 @@ public class EndMetalsOreSpawn implements Function<OreSpawnAPI, SpawnLogic> {
 		SpawnLogic logic = api.createSpawnLogic();
 
 		// Vanilla
-		logic.getDimension(-1)
-				.addOre(Materials.getMaterialByName("coal").oreNether.getDefaultState(), 10, 8,  12, 0,  200)
-				.addOre(Materials.getMaterialByName("diamond").oreNether.getDefaultState(), 2, 8,  12, 0,  200)
-				.addOre(Materials.getMaterialByName("emerald").oreNether.getDefaultState(), 4, 8,  12, 0,  200)
-				.addOre(Materials.getMaterialByName("gold").oreNether.getDefaultState(), 5, 8,  12, 0,  200)
-				.addOre(Materials.getMaterialByName("iron").oreNether.getDefaultState(), 10, 8,  12, 0,  200);
-				/*
-				.addOre(ModBlocks.lapisOre.getDefaultState(), 8, 8,  12, 0,  96)
-				.addOre(ModBlocks.redstoneOre.getDefaultState(), 8, 8,  12, 0,  96);
-		 		*/
+		logic.getDimension(1)
+		.addOre(Materials.getMaterialByName("coal").oreEnd.getDefaultState(), 10, 8,  12, 0,  200)
+		.addOre(Materials.getMaterialByName("diamond").oreEnd.getDefaultState(), 2, 8,  12, 0,  200)
+		.addOre(Materials.getMaterialByName("emerald").oreEnd.getDefaultState(), 4, 8,  12, 0,  200)
+		.addOre(Materials.getMaterialByName("gold").oreEnd.getDefaultState(), 5, 8,  12, 0,  200)
+		.addOre(Materials.getMaterialByName("iron").oreEnd.getDefaultState(), 10, 8,  12, 0,  200)
+		.addOre(Materials.getMaterialByName("lapis").oreEnd.getDefaultState(), 8, 8,  12, 0,  96)
+		.addOre(Materials.getMaterialByName("redstone").oreEnd.getDefaultState(), 8, 8,  12, 0,  96);
 
 		//Base Metals
 		if (Loader.isModLoaded("basemetals")) {
-			logic.getDimension(-1)
-					.addOre(Materials.getMaterialByName("antimony").oreNether.getDefaultState(), 8, 4, 10, 0,  200)
-					.addOre(Materials.getMaterialByName("bismuth").oreNether.getDefaultState(), 8, 4,  10, 0,  200)
-					.addOre(Materials.getMaterialByName("copper").oreNether.getDefaultState(), 10, 12,  20, 0,  200)
-					.addOre(Materials.getMaterialByName("lead").oreNether.getDefaultState(), 8, 12,  20, 0,  200)
-					.addOre(Materials.getMaterialByName("mercury").oreNether.getDefaultState(), 4, 4,  10, 0,  200)
-					.addOre(Materials.getMaterialByName("nickel").oreNether.getDefaultState(), 6, 4,  10, 0,  200)
-					.addOre(Materials.getMaterialByName("platinum").oreNether.getDefaultState(), 2, 4,  10, 0,  200)
-					.addOre(Materials.getMaterialByName("silver").oreNether.getDefaultState(), 8, 8,  10, 0,  200)
-					.addOre(Materials.getMaterialByName("tin").oreNether.getDefaultState(), 10, 12,  20, 0,  200)
-					.addOre(Materials.getMaterialByName("zinc").oreNether.getDefaultState(), 6, 8,  12, 0,  200);
+			if( com.mcmoddev.basemetals.util.Config.Options.enableAntimony ) {
+				logic.getDimension(1).addOre(Materials.getMaterialByName("antimony").oreEnd.getDefaultState(), 8, 4, 10, 0,  200);
+			}
+
+			if( com.mcmoddev.basemetals.util.Config.Options.enableBismuth ) {
+				logic.getDimension(1).addOre(Materials.getMaterialByName("bismuth").oreEnd.getDefaultState(), 8, 4,  10, 0,  200);
+			}
+
+			if( com.mcmoddev.basemetals.util.Config.Options.enableCopper ) {
+				logic.getDimension(1).addOre(Materials.getMaterialByName("copper").oreEnd.getDefaultState(), 10, 12,  20, 0,  200);
+			}
+
+			if( com.mcmoddev.basemetals.util.Config.Options.enableLead ) {
+				logic.getDimension(1).addOre(Materials.getMaterialByName("lead").oreEnd.getDefaultState(), 8, 12,  20, 0,  200);
+			}
+
+			if( com.mcmoddev.basemetals.util.Config.Options.enableMercury ) {
+				logic.getDimension(1).addOre(Materials.getMaterialByName("mercury").oreEnd.getDefaultState(), 4, 4,  10, 0,  200);
+			}
+
+			if( com.mcmoddev.basemetals.util.Config.Options.enableNickel ) {
+				logic.getDimension(1).addOre(Materials.getMaterialByName("nickel").oreEnd.getDefaultState(), 6, 4,  10, 0,  200);
+			}
+
+			if( com.mcmoddev.basemetals.util.Config.Options.enablePlatinum ) {
+				logic.getDimension(1).addOre(Materials.getMaterialByName("platinum").oreEnd.getDefaultState(), 2, 4,  10, 0,  200);
+			}
+
+			if( com.mcmoddev.basemetals.util.Config.Options.enableSilver ) {
+				logic.getDimension(1).addOre(Materials.getMaterialByName("silver").oreEnd.getDefaultState(), 8, 8,  10, 0,  200);
+			}
+
+			if( com.mcmoddev.basemetals.util.Config.Options.enableTin ) {
+				logic.getDimension(1).addOre(Materials.getMaterialByName("tin").oreEnd.getDefaultState(), 10, 12,  20, 0,  200);
+			}
+
+			if( com.mcmoddev.basemetals.util.Config.Options.enableZinc ) {
+				logic.getDimension(1).addOre(Materials.getMaterialByName("zinc").oreEnd.getDefaultState(), 6, 8,  12, 0,  200);
+			}
 		}
 
 		//Modern Metals
 		if (Loader.isModLoaded("modernmetals")) {
-			logic.getDimension(-1)
-					.addOre(Materials.getMaterialByName("aluminum").oreNether.getDefaultState(), 10, 8,  10, 0,  200)
-					.addOre(Materials.getMaterialByName("cadmium").oreNether.getDefaultState(), 4, 8,  10, 0,  200)
-					.addOre(Materials.getMaterialByName("chromium").oreNether.getDefaultState(), 4, 8,  10, 0,  200)
-					.addOre(Materials.getMaterialByName("iridium").oreNether.getDefaultState(), 6, 8,  10, 0,  200)
-					.addOre(Materials.getMaterialByName("magnesium").oreNether.getDefaultState(), 6, 8,  10, 0,  200)
-					.addOre(Materials.getMaterialByName("manganese").oreNether.getDefaultState(), 6, 8,  10, 0,  200)
-					.addOre(Materials.getMaterialByName("osmium").oreNether.getDefaultState(), 10, 8,  10, 0,  200)
-					.addOre(Materials.getMaterialByName("plutonium").oreNether.getDefaultState(), 4, 4,  10, 0,  200)
-					.addOre(Materials.getMaterialByName("rutile").oreNether.getDefaultState(), 8, 8,  10, 0,  200)
-					.addOre(Materials.getMaterialByName("tantalum").oreNether.getDefaultState(), 8, 8,  10, 0,  200)
-					.addOre(Materials.getMaterialByName("titanium").oreNether.getDefaultState(), 4, 4,  10, 0,  200)
-					.addOre(Materials.getMaterialByName("tungsten").oreNether.getDefaultState(), 8, 8,  10, 0,  200)
-					.addOre(Materials.getMaterialByName("uranium").oreNether.getDefaultState(), 2, 4,  10, 0,  200)
-					.addOre(Materials.getMaterialByName("zirconium").oreNether.getDefaultState(), 8, 8,  10, 0,  200);
+			if( com.mcmoddev.modernmetals.util.Config.Options.enableAluminum ) {
+				logic.getDimension(1).addOre(Materials.getMaterialByName("aluminum").oreEnd.getDefaultState(), 10, 8,  10, 0,  200);
+			}
+
+			if( com.mcmoddev.modernmetals.util.Config.Options.enableCadmium ) {
+				logic.getDimension(1).addOre(Materials.getMaterialByName("cadmium").oreEnd.getDefaultState(), 4, 8,  10, 0,  200);
+			}
+
+			if( com.mcmoddev.modernmetals.util.Config.Options.enableChromium ) {
+				logic.getDimension(1).addOre(Materials.getMaterialByName("chromium").oreEnd.getDefaultState(), 4, 8,  10, 0,  200);
+			}
+
+			if( com.mcmoddev.modernmetals.util.Config.Options.enableIridium ) {
+				logic.getDimension(1).addOre(Materials.getMaterialByName("iridium").oreEnd.getDefaultState(), 6, 8,  10, 0,  200);
+			}
+
+			if( com.mcmoddev.modernmetals.util.Config.Options.enableMagnesium ) {
+				logic.getDimension(1).addOre(Materials.getMaterialByName("magnesium").oreEnd.getDefaultState(), 6, 8,  10, 0,  200);
+			}
+
+			if( com.mcmoddev.modernmetals.util.Config.Options.enableManganese ) {
+				logic.getDimension(1).addOre(Materials.getMaterialByName("manganese").oreEnd.getDefaultState(), 6, 8,  10, 0,  200);
+			}
+
+			if( com.mcmoddev.modernmetals.util.Config.Options.enableOsmium ) {
+				logic.getDimension(1).addOre(Materials.getMaterialByName("osmium").oreEnd.getDefaultState(), 10, 8,  10, 0,  200);
+			}
+
+			if( com.mcmoddev.modernmetals.util.Config.Options.enablePlutonium ) {
+				logic.getDimension(1).addOre(Materials.getMaterialByName("plutonium").oreEnd.getDefaultState(), 4, 4,  10, 0,  200);
+			}
+
+			if( com.mcmoddev.modernmetals.util.Config.Options.enableRutile ) {
+				logic.getDimension(1).addOre(Materials.getMaterialByName("rutile").oreEnd.getDefaultState(), 8, 8,  10, 0,  200);
+			}
+
+			if( com.mcmoddev.modernmetals.util.Config.Options.enableTantalum ) {
+				logic.getDimension(1).addOre(Materials.getMaterialByName("tantalum").oreEnd.getDefaultState(), 8, 8,  10, 0,  200);
+			}
+
+			if( com.mcmoddev.modernmetals.util.Config.Options.enableTitanium ) {
+				logic.getDimension(1).addOre(Materials.getMaterialByName("titanium").oreEnd.getDefaultState(), 4, 4,  10, 0,  200);
+			}
+
+			if( com.mcmoddev.modernmetals.util.Config.Options.enableTungsten ) {
+				logic.getDimension(1).addOre(Materials.getMaterialByName("tungsten").oreEnd.getDefaultState(), 8, 8,  10, 0,  200);
+			}
+
+			if( com.mcmoddev.modernmetals.util.Config.Options.enableUranium ) {
+				logic.getDimension(1).addOre(Materials.getMaterialByName("uranium").oreEnd.getDefaultState(), 2, 4,  10, 0,  200);
+			}
+
+			if( com.mcmoddev.modernmetals.util.Config.Options.enableZirconium ) {
+				logic.getDimension(1).addOre(Materials.getMaterialByName("zirconium").oreEnd.getDefaultState(), 8, 8,  10, 0,  200);;
+			}
 		}
 
 		return logic;


### PR DESCRIPTION
End Metals OreSpawn 2 integration looks like it was just a copypasta from NetherMetals right now. This changes it to use the correct dimension identifier and the correct ore-names, as well as fixing things so that it won't try and register spawns for materials that are disabled.